### PR TITLE
Add missing return statement

### DIFF
--- a/include/Core/EvolutionContext.h
+++ b/include/Core/EvolutionContext.h
@@ -146,7 +146,7 @@ public:
   }
 
   bool setCDatabase(const ::std::string &cdpath){
-    this->eeHelper.setCompilationDatabase(cdpath);
+    return this->eeHelper.setCompilationDatabase(cdpath);
   }
  
   void setAprxLoc(const ::bellerophon::core::AprxLocationVector &v){this->locations=v;}


### PR DESCRIPTION
Without this, initialization may fail depending on how it is compiled.